### PR TITLE
fix(mixin form_input): associate label with input

### DIFF
--- a/src/pug/templates/_global_mixins.pug
+++ b/src/pug/templates/_global_mixins.pug
@@ -40,7 +40,7 @@ mixin form_input(data)
 		if data.label
 			label(for=data.id class= labelClass)= data.label
 		div(class = fieldClass)
-			input(type=data.type class = elClass placeholder=data.placeholder value=data.value name=data.name required=data.required)
+			input(type=data.type class = elClass id=data.id placeholder=data.placeholder value=data.value name=data.name required=data.required)
 			block
 
 mixin form_textarea(data)


### PR DESCRIPTION
The `for` attribute of the `label` element is set to `data.id`. However,
the `input` element itself has not been given an `id` attribute. I added
an `id` attribute to the `input` element to fix the association of the
`label` element with the `input` element.