### PR TITLE
improve: Optimize Pug mixins compiling

### DIFF
--- a/src/pug/layout/_layout.pug
+++ b/src/pug/layout/_layout.pug
@@ -1,7 +1,11 @@
 include ../templates/_global_vars
 include ../templates/_global_mixins
-include ../templates/_project_vars
-include ../templates/_project_mixins
+include ../templates/mixins/_m_header
+include ../templates/mixins/_m_footer
+
+//- It is commented for optimization reasons
+//- include ../templates/_project_vars
+//- include ../templates/_project_mixins
 
 block vars
 block project_vars

--- a/src/pug/templates/_project_mixins.pug
+++ b/src/pug/templates/_project_mixins.pug
@@ -1,2 +1,3 @@
-include mixins/_m_header
-include mixins/_m_footer
+//- It is commented for optimization reasons
+//- include mixins/_m_header
+//- include mixins/_m_footer


### PR DESCRIPTION
Prior to this commit, Pug mixin files were included in the
*src/pug/templates/_project_mixins.pug* file, which in turn was included
in the *src/pug/layout/_layout.pug* file. Therefore, any change in the
mixin file caused a rebuild of *_layout.pug*, and, consequently, all
pages of the project.

To avoid this problem, from now on the project mixin files will be
included directly where they are used.

It was decided to leave the inclusion of global mixin files in
*_layout.pug*, because these mixins do not change often.

The situation is similar with project and global variables.